### PR TITLE
Updates to books test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.8.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ You have been tasked with writing Ruby code that parses two files of book meta-d
 Clarifying-questions, use of online resources, and code libraries are all fair game.
 
 You have 45 minutes to complete this task.
+
+## Setup
+
+1. After cloning the repository, execute `bundle install`.
+	
+2. Verify the setup by running the tests:
+
+	`bundle exec ruby books_test.rb`

--- a/books_test.rb
+++ b/books_test.rb
@@ -19,9 +19,10 @@ class BooksTest < Minitest::Test
 
   def test_weight
     assert_equal ["weight"], @result.scan(/weight/)
-    assert_equal ["unit"], @result.scan(/unit/)
-    assert_equal ["box"], @result.scan(/box/)
-    assert_equal ["shipping"], @result.scan(/shipping/)
+    assert_equal [%Q("unit": 2.34)], @result.scan(/"unit": 2.34/)
+    assert_equal [%Q("box": 0.56)], @result.scan(/"box": 0.56/)
+    assert_equal [%Q("shipping": 2.9)], @result.scan(/"shipping": 2.9/)
+    assert_equal [%Q("gross": 3.78)], @result.scan(/"gross": 3.78/)
   end
 
   def test_copyright

--- a/books_test.rb
+++ b/books_test.rb
@@ -1,8 +1,8 @@
-require "test/unit"
+require "minitest/autorun"
 
-class BooksTest < Test::Unit::TestCase
+class BooksTest < Minitest::Test 
   def setup
-    @result = File.open('result_example.file', 'rb').read
+    @result = File.read("result_example.file")
   end
 
   def test_isbn

--- a/books_test.rb
+++ b/books_test.rb
@@ -1,6 +1,6 @@
 require "test/unit"
 
-class BookTest < Test::Unit::TestCase
+class BooksTest < Test::Unit::TestCase
   def setup
     @result = File.open('result_example.file', 'rb').read
   end

--- a/result_example.file
+++ b/result_example.file
@@ -8,7 +8,8 @@
   "weight": {
     "unit": 2.34,
     "box": 0.56,
-    "shipping": 2.9
+    "shipping": 2.9,
+    "gross": 3.78
   },
   "copyright": [
     "1981",

--- a/source1.file
+++ b/source1.file
@@ -4,7 +4,8 @@
   "authors": ["Joe Blow", "John Doe"],
   "weight": {
     "unit": 2.34,
-    "shipping": 2.9
+    "shipping": 2.9,
+    "gross": 3.78
   },
   "copyright": {
     "1981": "Joe Blow and John Doe",


### PR DESCRIPTION
Uses bundler to replace Test::Unit with Minitest so that candidates aren't required to install the library in their system gems.

Lastly adds gross value to the weight attributes.