### PR TITLE
Allow unprettyfied json to pass test regexes

### DIFF
--- a/books_test.rb
+++ b/books_test.rb
@@ -1,42 +1,48 @@
 require "minitest/autorun"
 
-class BooksTest < Minitest::Test 
+class BooksTest < Minitest::Test
   def setup
     @result = File.read("result_example.file")
   end
 
   def test_isbn
-    assert_equal ["isbn"], @result.scan(/isbn/)
+    assert_presence_of(/isbn/)
   end
 
   def test_title
-    assert_equal ["title"], @result.scan(/title/)
+    assert_presence_of(/title/)
   end
 
   def test_authors
-    assert_equal 1, @result.scan(/"authors": \[\s*"Joe Blow",\s*"John Doe"\s*\]/m).size
+    assert_presence_of(/"authors": ?\[\s*"Joe Blow",\s*"John Doe"\s*\]/m)
   end
 
   def test_weight
-    assert_equal ["weight"], @result.scan(/weight/)
-    assert_equal [%Q("unit": 2.34)], @result.scan(/"unit": 2.34/)
-    assert_equal [%Q("box": 0.56)], @result.scan(/"box": 0.56/)
-    assert_equal [%Q("shipping": 2.9)], @result.scan(/"shipping": 2.9/)
-    assert_equal [%Q("gross": 3.78)], @result.scan(/"gross": 3.78/)
+    assert_presence_of(/weight/)
+    assert_presence_of(/"unit": ?2.34/)
+    assert_presence_of(/"box": ?0.56/)
+    assert_presence_of(/"shipping": ?2.9/)
+    assert_presence_of(/"gross": ?3.78/)
   end
 
   def test_copyright
-    assert_equal ["copyright"], @result.scan(/copyright/)
-    assert_equal ["1981", "1981"], @result.scan(/1981/)
+    assert_presence_of(/copyright/)
+    assert_presence_of(/1981/, 2)
   end
 
   def test_pages
-    assert_equal ["pages"], @result.scan(/pages/)
-    assert_equal ["112"], @result.scan(/112/)
+    assert_presence_of(/pages/)
+    assert_presence_of(/112/)
   end
 
   def test_in_stock
-    assert_equal ["in_stock"], @result.scan(/in_stock/)
-    assert_equal ["1635"], @result.scan(/1635/)
+    assert_presence_of(/in_stock/)
+    assert_presence_of(/1635/)
   end
+
+  private
+
+    def assert_presence_of(pattern, expected_count = 1)
+      assert_equal(expected_count, @result.scan(pattern).size)
+    end
 end


### PR DESCRIPTION
Jay and i ran into candidates spitting out correct but unprettyfied json. I think the test should pass regardless of the formatting since we specifically say that in the readme.

Also dry's up the test a little.